### PR TITLE
Added an easily-configurable mapping configuration GUI, seed collection importing, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ An ArchivesSpace plugin for importing Archive-It seeds. Imported seeds generate 
         routes.rb
     schemas\
         archive_it_import_job.rb
-    archive-it_mapping.json   (Auto-generated)
     config.yml
 
 ## Data Model

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ An ArchivesSpace plugin for importing Archive-It seeds. Imported seeds generate 
     backend\
         controllers\
             archive_it.rb
+        job_runners\
+            archive_it_collection_importer.rb
         model\
             lib\
                 archive_it_export.rb
@@ -17,6 +19,7 @@ An ArchivesSpace plugin for importing Archive-It seeds. Imported seeds generate 
             add_archive_it_link.js
         controllers\
             archive_it_controller.rb
+            archive_it_collection_map_controller.rb
         locales\
             en.yml
         models\
@@ -24,9 +27,17 @@ An ArchivesSpace plugin for importing Archive-It seeds. Imported seeds generate 
         views\
             archive_it\
                 index.html.erb
+            archive_it_collection_map\
+                index.html.erb
+            archive_it_import_job\
+                _form.html.erb
+                _show.html.erb
             layout_head.html.erb
         plugin_init.rb
         routes.rb
+    schemas\
+        archive_it_import_job.rb
+    archive-it_mapping.json   (Auto-generated)
     config.yml
 
 ## Data Model
@@ -43,22 +54,8 @@ This plugin assumes a data model in which each Archive-It collection corresponds
               Digital Object Instance
 
 ## Usage
-To enable this plugin, clone this repository to your ArchivesSpace installation's `plugins/` directory and add `bhl_aspace_archive_it` to `AppConfig[:plugins]` in your ArchivesSpace `config.rb`. Then, add an `AppConfig[:archive_it]` entry in `config.rb` mapping Archive-It collection IDs to ArchivesSpace resource IDs, like so:
+To enable this plugin, clone this repository to your ArchivesSpace installation's `plugins/` directory.
 
-```
-AppConfig[:archive_it] = {
-           :collection_map => {
-               "5476" => 9332,
-               "5486" => 9333,
-               "5866" => 9334,
-               "5867" => 9335,
-               "5868" => 9336,
-               "5869" => 9337,
-               "5870" => 9338,
-               "5871" => 9339
-           }
-        }
-```
 To import a new seed URL into ArchivesSpace, navigate to the repository settings menu (gear icon) in ArchivesSpace and select "Archive-It Import" from the "Plug-ins" drop down menu. You will be taken to the following screen in ArchivesSpace:
 
 ![Archive-It Import Screen](docs/screenshot.PNG "The Archive-It Import Screen")

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This plugin assumes a data model in which each Archive-It collection corresponds
               Digital Object Instance
 
 ## Usage
-To enable this plugin, clone this repository to your ArchivesSpace installation's `plugins/` directory.
+To enable this plugin, clone this repository to your ArchivesSpace installation's `plugins/` directory and add `bhl_aspace_archive_it` to `AppConfig[:plugins]` in your ArchivesSpace `config.rb`.
 
 To import a new seed URL into ArchivesSpace, navigate to the repository settings menu (gear icon) in ArchivesSpace and select "Archive-It Import" from the "Plug-ins" drop down menu. You will be taken to the following screen in ArchivesSpace:
 

--- a/backend/controllers/archive_it.rb
+++ b/backend/controllers/archive_it.rb
@@ -1,38 +1,37 @@
 require_relative "../model/lib/archive_it_export"
 class ArchivesSpaceService < Sinatra::Base
-  include ArchiveItExport
+    include ArchiveItExport
 
-  Endpoint.get('/repositories/:repo_id/archive_it/marc_candidates')
-    .description("Get a list of MARC record candidates")
-    .params(["repo_id", :repo_id])
-    .permissions(["view_repository"])
-    .returns([200, "OK"]) \
-  do
-    candidates = ArchiveIt.get_marc_candidates
+    Endpoint.get('/repositories/:repo_id/archive_it/marc_candidates')
+        .description("Get a list of MARC record candidates")
+        .params(["repo_id", :repo_id])
+        .permissions(["view_repository"])
+        .returns([200, "OK"]) \
+    do
+		candidates = ArchiveIt.get_marc_candidates
 
-    json_response(:results => candidates)
-  end
+		json_response(:results => candidates)
+    end
 
-  Endpoint.get('/repositories/:repo_id/archive_it/archive_it_collections')
-    .description("Get a mapping of Archive-It collections and ArchivesSpace Resources")
-    .params(["repo_id", :repo_id])
-    .permissions(["view_repository"])
-    .returns([200, "OK"]) \
-  do
-    collection_resource_map = ArchiveIt.get_archive_it_collection_map
+    Endpoint.get('/current_archive_it_mapping')
+		.description("Get a mapping of Archive-It collections and ArchivesSpace Resources")
+		.permissions([])
+		.returns([200, "OK"]) \
+    do
+		collection_resource_map = ArchiveIt.get_archive_it_collection_map
 
-    json_response(collection_resource_map)
-  end
+		json_response(collection_resource_map)
+    end
 
-  Endpoint.get('/repositories/:repo_id/archive_it/archive_it_marc/:id.xml')
-    .description("Get a MARC 21 representation of a site-level Archival Object")
-    .params(["id", :id],
-            ["repo_id", :repo_id])
-    .permissions([:view_repository])
-    .returns([200, "(:resource)"]) \
-  do
-    marc = generate_archive_it_marc(params[:id])
+    Endpoint.get('/repositories/:repo_id/archive_it/archive_it_marc/:id.xml')
+		.description("Get a MARC 21 representation of a site-level Archival Object")
+		.params(["id", :id],
+				["repo_id", :repo_id])
+		.permissions([:view_repository])
+		.returns([200, "(:resource)"]) \
+    do
+		marc = generate_archive_it_marc(params[:id])
 
-    xml_response(marc)
-  end
+		xml_response(marc)
+    end
 end

--- a/backend/controllers/archive_it.rb
+++ b/backend/controllers/archive_it.rb
@@ -1,37 +1,37 @@
 require_relative "../model/lib/archive_it_export"
 class ArchivesSpaceService < Sinatra::Base
-    include ArchiveItExport
+  include ArchiveItExport
 
-    Endpoint.get('/repositories/:repo_id/archive_it/marc_candidates')
-        .description("Get a list of MARC record candidates")
-        .params(["repo_id", :repo_id])
-        .permissions(["view_repository"])
-        .returns([200, "OK"]) \
-    do
-		candidates = ArchiveIt.get_marc_candidates
+  Endpoint.get('/repositories/:repo_id/archive_it/marc_candidates')
+    .description("Get a list of MARC record candidates")
+    .params(["repo_id", :repo_id])
+    .permissions(["view_repository"])
+    .returns([200, "OK"]) \
+  do
+    candidates = ArchiveIt.get_marc_candidates
 
-		json_response(:results => candidates)
-    end
+    json_response(:results => candidates)
+  end
 
-    Endpoint.get('/current_archive_it_mapping')
-		.description("Get a mapping of Archive-It collections and ArchivesSpace Resources")
-		.permissions([])
-		.returns([200, "OK"]) \
-    do
-		collection_resource_map = ArchiveIt.get_archive_it_collection_map
+  Endpoint.get('/current_archive_it_mapping')
+    .description("Get a mapping of Archive-It collections and ArchivesSpace Resources")
+    .permissions([])
+    .returns([200, "OK"]) \
+  do
+    collection_resource_map = ArchiveIt.get_archive_it_collection_map
 
-		json_response(collection_resource_map)
-    end
+    json_response(collection_resource_map)
+  end
 
-    Endpoint.get('/repositories/:repo_id/archive_it/archive_it_marc/:id.xml')
-		.description("Get a MARC 21 representation of a site-level Archival Object")
-		.params(["id", :id],
-				["repo_id", :repo_id])
-		.permissions([:view_repository])
-		.returns([200, "(:resource)"]) \
-    do
-		marc = generate_archive_it_marc(params[:id])
+  Endpoint.get('/repositories/:repo_id/archive_it/archive_it_marc/:id.xml')
+    .description("Get a MARC 21 representation of a site-level Archival Object")
+    .params(["id", :id],
+        ["repo_id", :repo_id])
+    .permissions([:view_repository])
+    .returns([200, "(:resource)"]) \
+  do
+    marc = generate_archive_it_marc(params[:id])
 
-		xml_response(marc)
-    end
+    xml_response(marc)
+  end
 end

--- a/backend/job_runners/archive_it_collection_importer.rb
+++ b/backend/job_runners/archive_it_collection_importer.rb
@@ -19,113 +19,86 @@ class ArchiveItCollectionImporter < JobRunner
 
                 params = JSON.parse(JSON.parse(@job.job_params))
 
-                backend_url = params['backend']
+                @backend_url = params['backend']
                 @session_key = params['session']
 
                 @collection_url = @json.job['collection_url']
                 collection_id = @collection_url.split("/")[-1]
                 @resource_uri = @json.job['resource_uri']
-                @archival_object_post_uri = "#{backend_url}/repositories/#{@job.repo_id}/archival_objects"
-                @digital_object_post_uri = "#{backend_url}/repositories/#{@job.repo_id}/digital_objects"
+                @archival_object_post_uri = "#{@backend_url}/repositories/#{@job.repo_id}/archival_objects"
+                @digital_object_post_uri = "#{@backend_url}/repositories/#{@job.repo_id}/digital_objects"
 
                 api_uri = URI("https://partner.archive-it.org/api/seed?collection=#{collection_id}&pluck=id&limit=10000")
                 response = Net::HTTP.get(api_uri)
 
-                @seed_ids = JSON.parse(response)
+                @seed_ids = JSON.parse(response).map{|seed|
+                    seed.to_s
+                }
 
                 JSONModel::HTTP.current_backend_session = @session_key
 
 
-                log("Updating #{backend_url}#{@resource_uri}")
-                log("This will delete the old objects and recreate them from the latest Archive-It data.")
-                log("")
+                log("Updating #{@backend_url}#{@resource_uri}")
+                log("This will update all seeds from the latest Archive-It data.")
         
+                @job.record_created_uris([@resource_uri]) # record_modified_uris doesn't work, so I'm using the next best thing   
+
+
+
                 ##########################################################
-                # Attempt to load the object tree so that we can delete everything
+                # Modify / create all the records
                 ##########################################################
-        
-                uri = URI("#{backend_url}#{@resource_uri}/tree")
-        
-                res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') { |http|
-                    req = Net::HTTP::Get.new(uri)
-                    req["X-ArchivesSpace-Session"] = @session_key
-        
-                    http.request(req)
-                }
-        
-                if res.code != "200" then
-                    log("Unable to access ArchivesSpace resource: #{@resource_uri}")
-                    log("")
-                    log("Response code: #{res.code}")
-                    log("Response body: #{res.body}")
-                    return
-                end
-        
-                tree = JSON.parse(res.body)
-        
-        
-        
-                ##########################################################
-                # Delete all of the old objects
-                ##########################################################
-        
-                log("")
-                log("Deleting old records...")
-                deleted_count = 0
-                
-                tree["children"].map{|child|
-                    endpoint = "#{@resource_uri.split("/").slice(0, 3).join("/")}/archival_objects/#{child["id"]}"
-                    uri = URI("#{backend_url}#{endpoint}")
-        
-                    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') { |http|
-                        req = Net::HTTP::Delete.new(uri)
-                        req["X-ArchivesSpace-Session"] = @session_key
-        
-                        http.request(req)
-                    }
-        
-                    log("    Deleted #{endpoint}")
-                    deleted_count += 1
-                }
-        
-        
-                
-                ##########################################################
-                # Now create all the new records
-                ##########################################################
-        
+
+                updated_count = 0
                 created_count = 0
-        
+
+                records = find_archival_objects(@seed_ids)
+
                 if @seed_ids.length > 0 then
                     log("")
                     log("")
-                    log("Now creating new records from Archive-It...")
-        
+                    log("Updating records from Archive-It...")
+
                     @seed_ids.map do |seed|
-                        create_archival_object(seed.to_s)
-                        created_count += 1
+
+                        if records[seed] then
+                            metadata = get_seed_metadata(seed)
+
+                            archival_uri = URI("#{@backend_url}#{records[seed]}")
+
+                            archival_object_response = get_json(archival_uri)
+                            archival_object = ASUtils.json_parse(archival_object_response.body)
+                            
+                            uri = refresh_archival_object(archival_object, seed, metadata, archival_uri)
+
+                            log("    Updated #{uri}")
+                            updated_count += 1
+                        else
+                            uri = create_archival_object(seed)
+
+                            log("    Created #{uri}")
+                            created_count += 1
+                        end
                     end
                 end
-                
-        
-        
+
+
+
                 ##########################################################
                 # Done! Tell the user what changes were made
                 ##########################################################
-        
+
                 redirect_url = @resource_uri.split("/").slice(3, 2).join("/")
-        
+
                 log("")
                 log("")
                 log("Finished! The resource /#{redirect_url} is updated.")
                 log("")
-                log("There were:  #{deleted_count} old object(s) deleted")
+                log("There were:  #{updated_count} old object(s) updated")
                 log("             #{created_count} new object(s) created")
                 log("")
-                log("Please click 'Refresh Page' to view the modified record.")
+                log("Please click 'Refresh Page' to view the modified resource.")
         
-                @job.record_created_uris([@resource_uri]) # record_modified_uris doesn't work, so I'm using the next best thing   
-
                 self.success!     
             end
         rescue Exception => e
@@ -134,6 +107,17 @@ class ArchiveItCollectionImporter < JobRunner
             raise e
         end
 	end
+
+    def get_json(uri)
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') { |http|
+            req = Net::HTTP::Get.new(uri)
+            req["X-ArchivesSpace-Session"] = @session_key
+
+            http.request(req)
+        }
+
+        res
+    end
 
 	def log(s)
 		Log.debug(s)
@@ -148,13 +132,32 @@ class ArchiveItCollectionImporter < JobRunner
         JSON.parse(response)
     end
 
+    def find_archival_objects(seed_ids)
+        hash = {}
+
+        seed_ids.map do |seed|
+            uri = URI("#{@backend_url}/repositories/#{@job.repo_id}/find_by_id/archival_objects?component_id[]=#{seed}")
+
+            res = get_json(uri)
+            objs = ASUtils.json_parse(res.body)["archival_objects"]
+
+            if objs[0] then
+                hash[seed] = objs[0]["ref"]
+            end
+        end
+
+        hash
+    end
+
     def create_digital_object(seed_metadata)
         wayback_url = "https://wayback.archive-it.org/#{seed_metadata['collection']}/*/#{seed_metadata['url']}"
+
         digital_object = JSONModel(:digital_object).new._always_valid!
-        digital_object.title = seed_metadata["url"]
         digital_object.digital_object_id = SecureRandom.hex
-        digital_object.file_versions = [{:file_uri => wayback_url, :xlink_show_attribute => 'new', :xlink_actuate_attribute => 'onRequest'}]
-        digital_object.notes = [{:type => 'note', :publish => true, :content => ['view captures'], :jsonmodel_type => 'note_digital_object'}]
+        
+        # The title value is not final. The refresh function will modify it
+        digital_object.title = seed_metadata["url"]
+        
         digital_object_response = JSONModel::HTTP::post_json(URI(@digital_object_post_uri), digital_object.to_json)
 
         result = ASUtils.json_parse(digital_object_response.body)
@@ -174,25 +177,77 @@ class ArchiveItCollectionImporter < JobRunner
         site_url = seed_metadata["url"]
 
 
-        archival_object = JSONModel(:archival_object).new._always_valid!
-
-        archival_object.resource = {'ref' => @resource_uri}
-        archival_object.title = site_url
-        archival_object.component_id = seed_id
-        archival_object.level = "otherlevel"
-        archival_object.other_level = "seed"
+        archival_object = JSONModel(:archival_object).new
         archival_object.instances = [{:instance_type => 'digital_object', :digital_object => {:ref => digital_object_uri}}]
 
-        archival_object.external_documents = [{:title => 'Archive-It URL', :location => "#{@collection_url}/seeds/#{seed_id}"}, {:title => 'Seed URL', :location => "#{seed_metadata['url']}"}]
+        if true then # These values are not final. They will be overwritten by refresh_archival_object()
+            archival_object.resource = {'ref' => @resource_uri}
+            archival_object.title = site_url
+            archival_object.component_id = seed_id
+            archival_object.level = "otherlevel"
+            archival_object.other_level = "seed"
+        end
         
-        archival_object_response = JSONModel::HTTP::post_json(URI(@archival_object_post_uri), archival_object.to_json)
+        refresh_archival_object(ASUtils.json_parse(archival_object.to_json), seed_id, seed_metadata, nil)
+    end
+
+    def refresh_archival_object(archival_object, seed_id, seed_metadata, archival_uri)
+        if seed_metadata["detail"] == "Not found" then
+            raise "seed_not_found:" + seed_id;
+        end
+
+
+
+        ##########################################################
+        # Update the digital object
+
+        digital_object_uri = "#{@backend_url}#{archival_object['instances'][0]['digital_object']['ref']}"
+        digital_object_response = get_json(URI(digital_object_uri))
+
+        digital_object = ASUtils.json_parse(digital_object_response.body)
+
+
+        wayback_url = "https://wayback.archive-it.org/#{seed_metadata['collection']}/*/#{seed_metadata['url']}"
+
+        digital_object['title'] = seed_metadata["url"]
+        digital_object['file_versions'] = [{:file_uri => wayback_url, :xlink_show_attribute => 'new', :xlink_actuate_attribute => 'onRequest'}]
+        digital_object['notes'] = [{:type => 'note', :publish => true, :content => ['view captures'], :jsonmodel_type => 'note_digital_object'}]
+
+
+
+        ##########################################################
+        # Update the archival object
+
+        archival_object['resource'] = {'ref' => @resource_uri}
+        archival_object['title'] = seed_metadata["url"]
+        archival_object['component_id'] = seed_id
+        archival_object['level'] = "otherlevel"
+        archival_object['other_level'] = "seed"
+
+
+
+        title = seed_metadata['metadata']['Title']
         
+        if title == nil then
+            title = "Seed URL"
+        else
+            title = title[0]['value']
+        end
+
+        archival_object['external_documents'] = [{'title' => 'Archive-It URL', 'location' => "#{@collection_url}/seeds/#{seed_id}"}, {'title' => title, 'location' => "#{seed_metadata['url']}"}]
+        
+
+
+        ##########################################################
+        # Save chnages to ArchivesSpace
+
+        archival_uri ||= @archival_object_post_uri
+        
+        archival_object_response = JSONModel::HTTP::post_json(URI(archival_uri), archival_object.to_json)
+
         result = ASUtils.json_parse(archival_object_response.body)
         archival_object_uri = result["uri"]
 
-        log("    Created #{archival_object_uri}")
-
         archival_object_uri
     end
-
 end

--- a/backend/job_runners/archive_it_collection_importer.rb
+++ b/backend/job_runners/archive_it_collection_importer.rb
@@ -197,6 +197,12 @@ class ArchiveItCollectionImporter < JobRunner
         end
 
 
+        title = seed_metadata['metadata']['Title']
+        
+        if title != nil then
+            title = title[0]['value']
+        end
+
 
         ##########################################################
         # Update the digital object
@@ -210,9 +216,15 @@ class ArchiveItCollectionImporter < JobRunner
         wayback_url = "https://wayback.archive-it.org/#{seed_metadata['collection']}/*/#{seed_metadata['url']}"
 
         digital_object['title'] = seed_metadata["url"]
-        digital_object['file_versions'] = [{:file_uri => wayback_url, :xlink_show_attribute => 'new', :xlink_actuate_attribute => 'onRequest'}]
-        digital_object['notes'] = [{:type => 'note', :publish => true, :content => ['view captures'], :jsonmodel_type => 'note_digital_object'}]
+        digital_object['file_versions'] = [{file_uri: wayback_url, xlink_show_attribute: 'new', xlink_actuate_attribute: 'onRequest'}]
+        
+        if title != nil then
+            digital_object['notes'] = [{type: 'note', publish: true, content: ["Website title: #{title}"], jsonmodel_type: 'note_digital_object'}]
+        else
+            digital_object['notes'] = []
+        end
 
+        digital_object_response = JSONModel::HTTP::post_json(URI(digital_object_uri), digital_object.to_json)
 
 
         ##########################################################
@@ -226,15 +238,7 @@ class ArchiveItCollectionImporter < JobRunner
 
 
 
-        title = seed_metadata['metadata']['Title']
-        
-        if title == nil then
-            title = "Seed URL"
-        else
-            title = title[0]['value']
-        end
-
-        archival_object['external_documents'] = [{'title' => 'Archive-It URL', 'location' => "#{@collection_url}/seeds/#{seed_id}"}, {'title' => title, 'location' => "#{seed_metadata['url']}"}]
+        archival_object['external_documents'] = [{'title' => 'Archive-It URL', 'location' => "#{@collection_url}/seeds/#{seed_id}"}, {'title' => title || "Seed URL", 'location' => "#{seed_metadata['url']}"}]
         
 
 

--- a/backend/job_runners/archive_it_collection_importer.rb
+++ b/backend/job_runners/archive_it_collection_importer.rb
@@ -39,7 +39,7 @@ class ArchiveItCollectionImporter < JobRunner
 
 
                 log("Updating #{@backend_url}#{@resource_uri}")
-                log("This will update all seeds from the latest Archive-It data.")
+                log("This will update all seeds with the latest Archive-It data.")
         
                 @job.record_created_uris([@resource_uri]) # record_modified_uris doesn't work, so I'm using the next best thing   
 
@@ -216,7 +216,8 @@ class ArchiveItCollectionImporter < JobRunner
         wayback_url = "https://wayback.archive-it.org/#{seed_metadata['collection']}/*/#{seed_metadata['url']}"
 
         digital_object['title'] = seed_metadata["url"]
-        digital_object['file_versions'] = [{file_uri: wayback_url, xlink_show_attribute: 'new', xlink_actuate_attribute: 'onRequest'}]
+        digital_object['file_versions'] = [{file_uri: wayback_url, xlink_show_attribute: 'new', xlink_actuate_attribute: 'onRequest', publish: true}]
+        digital_object['publish'] = true
         
         if title != nil then
             digital_object['notes'] = [{type: 'note', publish: true, content: ["Website title: #{title}"], jsonmodel_type: 'note_digital_object'}]

--- a/backend/job_runners/archive_it_collection_importer.rb
+++ b/backend/job_runners/archive_it_collection_importer.rb
@@ -1,0 +1,198 @@
+require 'java'
+require 'json'
+require 'uri'
+require 'net/http'
+require 'jsonmodel_client'
+
+class ArchiveItCollectionImporter < JobRunner
+
+	register_for_job_type('archive_it_import_job', :run_concurrently => false)
+
+    include JSONModel
+    include JSONModel::HTTP
+    include URI
+
+	def run
+        begin
+            RequestContext.open( :repo_id => @job.repo_id) do
+                resource_id = JSONModel.parse_reference(@json.job['resource_uri'])[:id]
+
+                params = JSON.parse(JSON.parse(@job.job_params))
+
+                backend_url = params['backend']
+                @session_key = params['session']
+
+                @collection_url = @json.job['collection_url']
+                collection_id = @collection_url.split("/")[-1]
+                @resource_uri = @json.job['resource_uri']
+                @archival_object_post_uri = "#{backend_url}/repositories/#{@job.repo_id}/archival_objects"
+                @digital_object_post_uri = "#{backend_url}/repositories/#{@job.repo_id}/digital_objects"
+
+                api_uri = URI("https://partner.archive-it.org/api/seed?collection=#{collection_id}&pluck=id&limit=10000")
+                response = Net::HTTP.get(api_uri)
+
+                @seed_ids = JSON.parse(response)
+
+                JSONModel::HTTP.current_backend_session = @session_key
+
+
+                log("Updating #{backend_url}#{@resource_uri}")
+                log("This will delete the old objects and recreate them from the latest Archive-It data.")
+                log("")
+        
+                ##########################################################
+                # Attempt to load the object tree so that we can delete everything
+                ##########################################################
+        
+                uri = URI("#{backend_url}#{@resource_uri}/tree")
+        
+                res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') { |http|
+                    req = Net::HTTP::Get.new(uri)
+                    req["X-ArchivesSpace-Session"] = @session_key
+        
+                    http.request(req)
+                }
+        
+                if res.code != "200" then
+                    log("Unable to access ArchivesSpace resource: #{@resource_uri}")
+                    log("")
+                    log("Response code: #{res.code}")
+                    log("Response body: #{res.body}")
+                    return
+                end
+        
+                tree = JSON.parse(res.body)
+        
+        
+        
+                ##########################################################
+                # Delete all of the old objects
+                ##########################################################
+        
+                log("")
+                log("Deleting old records...")
+                deleted_count = 0
+                
+                tree["children"].map{|child|
+                    endpoint = "#{@resource_uri.split("/").slice(0, 3).join("/")}/archival_objects/#{child["id"]}"
+                    uri = URI("#{backend_url}#{endpoint}")
+        
+                    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') { |http|
+                        req = Net::HTTP::Delete.new(uri)
+                        req["X-ArchivesSpace-Session"] = @session_key
+        
+                        http.request(req)
+                    }
+        
+                    log("    Deleted #{endpoint}")
+                    deleted_count += 1
+                }
+        
+        
+                
+                ##########################################################
+                # Now create all the new records
+                ##########################################################
+        
+                created_count = 0
+        
+                if @seed_ids.length > 0 then
+                    log("")
+                    log("")
+                    log("Now creating new records from Archive-It...")
+        
+                    @seed_ids.map do |seed|
+                        create_archival_object(seed.to_s)
+                        created_count += 1
+                    end
+                end
+                
+        
+        
+                ##########################################################
+                # Done! Tell the user what changes were made
+                ##########################################################
+        
+                redirect_url = @resource_uri.split("/").slice(3, 2).join("/")
+        
+                log("")
+                log("")
+                log("Finished! The resource /#{redirect_url} is updated.")
+                log("")
+                log("There were:  #{deleted_count} old object(s) deleted")
+                log("             #{created_count} new object(s) created")
+                log("")
+                log("Please click 'Refresh Page' to view the modified record.")
+        
+                @job.record_created_uris([@resource_uri]) # record_modified_uris doesn't work, so I'm using the next best thing   
+
+                self.success!     
+            end
+        rescue Exception => e
+            @job.write_output(e.message)
+            @job.write_output(e.backtrace)
+            raise e
+        end
+	end
+
+	def log(s)
+		Log.debug(s)
+		@job.write_output(s)
+	end
+
+
+    def get_seed_metadata(seed_id)
+        api_uri = URI("https://partner.archive-it.org/api/seed/#{seed_id}")
+        response = Net::HTTP.get(api_uri)
+
+        JSON.parse(response)
+    end
+
+    def create_digital_object(seed_metadata)
+        wayback_url = "https://wayback.archive-it.org/#{seed_metadata['collection']}/*/#{seed_metadata['url']}"
+        digital_object = JSONModel(:digital_object).new._always_valid!
+        digital_object.title = seed_metadata["url"]
+        digital_object.digital_object_id = SecureRandom.hex
+        digital_object.file_versions = [{:file_uri => wayback_url, :xlink_show_attribute => 'new', :xlink_actuate_attribute => 'onRequest'}]
+        digital_object.notes = [{:type => 'note', :publish => true, :content => ['view captures'], :jsonmodel_type => 'note_digital_object'}]
+        digital_object_response = JSONModel::HTTP::post_json(URI(@digital_object_post_uri), digital_object.to_json)
+
+        result = ASUtils.json_parse(digital_object_response.body)
+        digital_object_uri = result["uri"]
+        digital_object_uri
+    end
+
+    def create_archival_object(seed_id)
+        seed_metadata = get_seed_metadata(seed_id)
+
+        if seed_metadata["detail"] == "Not found" then
+            raise "seed_not_found:" + seed_id;
+        end
+
+        collection_id = seed_metadata["collection"].to_s
+        digital_object_uri = create_digital_object(seed_metadata)
+        site_url = seed_metadata["url"]
+
+
+        archival_object = JSONModel(:archival_object).new._always_valid!
+
+        archival_object.resource = {'ref' => @resource_uri}
+        archival_object.title = site_url
+        archival_object.component_id = seed_id
+        archival_object.level = "otherlevel"
+        archival_object.other_level = "seed"
+        archival_object.instances = [{:instance_type => 'digital_object', :digital_object => {:ref => digital_object_uri}}]
+
+        archival_object.external_documents = [{:title => 'Archive-It URL', :location => "#{@collection_url}/seeds/#{seed_id}"}, {:title => 'Seed URL', :location => "#{seed_metadata['url']}"}]
+        
+        archival_object_response = JSONModel::HTTP::post_json(URI(@archival_object_post_uri), archival_object.to_json)
+        
+        result = ASUtils.json_parse(archival_object_response.body)
+        archival_object_uri = result["uri"]
+
+        log("    Created #{archival_object_uri}")
+
+        archival_object_uri
+    end
+
+end

--- a/backend/model/archive_it.rb
+++ b/backend/model/archive_it.rb
@@ -32,7 +32,13 @@ class ArchiveIt
     end
 
     def self.get_archive_it_collection_map
-        AppConfig[:archive_it][:collection_map]
+        path = "#{__dir__}/../../archive_it_mapping.json"
+
+        if not File.file?(path) then
+            return "{}"
+        end
+        
+        File.open(path).read
     end
 
 end

--- a/backend/model/archive_it.rb
+++ b/backend/model/archive_it.rb
@@ -32,7 +32,7 @@ class ArchiveIt
     end
 
     def self.get_archive_it_collection_map
-        path = "#{__dir__}/../../archive_it_mapping.json"
+        path = "#{__dir__}/../../../../config/archive_it_mapping.json"
 
         if not File.file?(path) then
             return "{}"

--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -1,3 +1,5 @@
 require_relative 'model/lib/archive_it_export'
 require_relative 'model/lib/archive_it_marc_model'
 require_relative 'model/lib/archive_it_marc_serializer'
+
+#ArchiveItCollectionMapping.init

--- a/config.yml
+++ b/config.yml
@@ -1,2 +1,3 @@
+system_menu_controller: archive_it_collection_map
 repository_menu_controller: archive_it
 no_automatic_routes: true

--- a/frontend/controllers/archive_it_collection_map_controller.rb
+++ b/frontend/controllers/archive_it_collection_map_controller.rb
@@ -1,0 +1,57 @@
+class ArchiveItCollectionMapController < ApplicationController
+
+    set_access_control "view_repository" => [:index, :save_mapping, :get_current_mapping]
+
+    include ExportHelper
+    
+    def index
+        if(params["saved"]) then
+            flash.now[:success] = I18n.t("plugins.archive_it.messages.saved")
+            params.delete("saved")
+        end
+
+        if(params["fix"]) then
+            @fix = params["fix"]
+        end
+
+        @current_mapping = get_current_mapping
+    end
+
+    def save_mapping
+        # Parse params and obtain the collection mapping
+        rows = {}
+
+        params.each do |key, value|
+            if m = key.match(/row(\d+)(\w\w)/) then
+                row = rows[m.captures[0]] || {}
+
+                row[m.captures[1]] = value
+
+                rows[m.captures[0]] = row
+            end
+        end
+
+        mapping = {}
+
+        rows.each do |_, value|
+            if value["ai"] != nil && value["as"] != nil && value["ai"] != "" && value["as"] != "" then
+                mapping[value["ai"]] = value["as"]
+            end
+        end
+
+
+        # Save the mapping to a file
+        path = "#{__dir__}/../../archive_it_mapping.json"
+
+        File.open(path, 'w') do |file|
+            file.write(mapping.to_json)
+        end
+
+        # Refresh the page and show a success banner
+        redirect_to "/plugins/archive_it_collection_map?saved=true"
+    end
+
+    def get_current_mapping
+        JSON.parse(JSONModel::HTTP::get_json("/current_archive_it_mapping"))
+    end
+end

--- a/frontend/controllers/archive_it_collection_map_controller.rb
+++ b/frontend/controllers/archive_it_collection_map_controller.rb
@@ -41,7 +41,7 @@ class ArchiveItCollectionMapController < ApplicationController
 
 
         # Save the mapping to a file
-        path = "#{__dir__}/../../archive_it_mapping.json"
+        path = "#{__dir__}/../../../../config/archive_it_mapping.json"
 
         File.open(path, 'w') do |file|
             file.write(mapping.to_json)

--- a/frontend/controllers/archive_it_controller.rb
+++ b/frontend/controllers/archive_it_controller.rb
@@ -1,10 +1,25 @@
-class ArchiveItController < ApplicationController
+class ArchiveItController < JobsController
 
     set_access_control "view_repository" => [:index, :import, :download_marc]
+    alias_method :create_job, :create
 
     include ExportHelper
     
     def index
+        if params["error"] then
+            p params["error"]
+            error, id, id2 = params["error"].split(':')
+
+            errorMessage = I18n.t("plugins.archive_it.errors.#{error}")
+
+            flash.now[:error] = eval("\"#{errorMessage}\"".gsub(/\\/, ""))
+
+            if error == "no_mapping" || error = "no_resource" then
+                @fix_collection = id
+            end
+        else
+      	    flash.now[:info] = I18n.t("plugins.archive_it.messages.service_notice")
+        end
     end
 
     def download_marc
@@ -14,13 +29,16 @@ class ArchiveItController < ApplicationController
 
     def import
         seed_url = params["seed_url"]
-        archival_object_post_uri = "#{JSONModel::HTTP.backend_url}/repositories/#{session[:repo_id]}/archival_objects"
-        digital_object_post_uri = "#{JSONModel::HTTP.backend_url}/repositories/#{session[:repo_id]}/digital_objects"
-        collection_resource_map_uri = "/repositories/#{session[:repo_id]}/archive_it/archive_it_collections"
-        importer = ArchiveItImporter.new(seed_url, archival_object_post_uri, digital_object_post_uri, collection_resource_map_uri)
-        archival_object_uri = importer.create_archival_object
-        resolver = Resolver.new(archival_object_uri)
-        redirect_to resolver.view_uri
+
+        begin
+            importer = ArchiveItImporter.new(seed_url, session)
+
+            redirect_url = importer.create_archival_objects
+        rescue Exception => ex
+            redirect_url = "/plugins/archive_it?error=#{ex.message}"
+        end
+
+        redirect_to redirect_url
     end
 
     private
@@ -31,17 +49,17 @@ class ArchiveItController < ApplicationController
         meta["filename"] = "archive_it_marc.xml"
 
         respond_to do |format|
-          format.html {
-            self.response.headers["Content-Type"] = meta['mimetype'] if meta['mimetype']
-            self.response.headers["Content-Disposition"] = "attachment; filename=#{meta['filename']}"
-            self.response.headers['Last-Modified'] = Time.now.ctime.to_s
+			format.html {
+				self.response.headers["Content-Type"] = meta['mimetype'] if meta['mimetype']
+				self.response.headers["Content-Disposition"] = "attachment; filename=#{meta['filename']}"
+				self.response.headers['Last-Modified'] = Time.now.ctime.to_s
 
-            self.response_body = Enumerator.new do |y|
-              xml_response(request_uri, params) do |chunk, percent|
-                y << chunk if !chunk.blank?
-              end
-            end
-          }
+				self.response_body = Enumerator.new do |y|
+				xml_response(request_uri, params) do |chunk, percent|
+					y << chunk if !chunk.blank?
+				end
+				end
+			}
         end
     end
 

--- a/frontend/controllers/archive_it_controller.rb
+++ b/frontend/controllers/archive_it_controller.rb
@@ -33,12 +33,19 @@ class ArchiveItController < JobsController
         begin
             importer = ArchiveItImporter.new(seed_url, session)
 
-            redirect_url = importer.create_archival_objects
+            redirect_url, isCreated = importer.create_archival_objects
+
         rescue Exception => ex
             redirect_url = "/plugins/archive_it?error=#{ex.message}"
         end
 
         redirect_to redirect_url
+        
+        if isCreated then
+            flash[:success] = I18n.t("plugins.archive_it.messages.seed_created")
+        elsif isCreated == false then
+            flash[:success] = I18n.t("plugins.archive_it.messages.seed_overwritten")
+        end
     end
 
     private

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -21,6 +21,8 @@ en:
         enter_ai_id: Enter Archive-It collection ID
         enter_as_id: Enter ArchivesSpace resource ID
         link_to_mapping: Configure the collection mapping here
+        seed_created: This object was newly created for this seed.
+        seed_overwritten: This object was updated with the latest seed metadata.
       errors:
         no_mapping: No mapping existed for the collection ID \#{id}.
         collection_not_found: No seeds were found for collection ID \#{id}. Does the collection exist and is it public?

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -41,7 +41,7 @@ en:
           <br>
           <div>To import a public collection:</div>
           <div>The collection URL should look like: https://partner.archive-it.org/[organization_id]/collections/[collection_id]</div>
-          <div>The new archival objects will be created for each public seed. This will run as a background job.</div>
+          <div>The old archival objects will be replaced with new archival objects for each seed. This will run as a background job.</div>
           <br>
           <div>Note that collections must first be mapped to resources before they can be imported.</div>
         begin_job_page: |

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -37,13 +37,17 @@ en:
         importing_url: |
           <div>Copy and paste a public seed or collection URL from the Archive-It administrative interface.</div>
           <br>
-          <div>To import a public seed:</div>
-          <div>The seed URL should look like: https://partner.archive-it.org/[organization_id]/collections/[collection_id]/seeds/[seed_id]</div>
-          <div>A new archival object will be created for the seed. You will be redirected to the new archival object.</div>
+          <div>How importing works:</div>
+          <div>&emsp;&emsp;The collection ID of the provided Archive-It URL is used to find the corresponding ArchivesSpace resource ID using the <a href="/plugins/archive_it_collection_map">collection map</a>.</div>
+          <div>&emsp;&emsp;Then an archival object will be created for each seed and stored in the object hierarchy of the correspondingly-mapped resource.</div>
+          <div>&emsp;&emsp;If a seed has already been imported, the archival object's seed metadata will be overwritten with the latest metadata from Archive-It.</div>
           <br>
-          <div>To import a public collection:</div>
-          <div>The collection URL should look like: https://partner.archive-it.org/[organization_id]/collections/[collection_id]</div>
-          <div>The old archival objects will be replaced with new archival objects for each seed. This will run as a background job.</div>
+          <div>When importing a public seed:</div>
+          <div>&emsp;&emsp;The seed URL should look like: https://partner.archive-it.org/[organization_id]/collections/[collection_id]/seeds/[seed_id]</div>
+          <br>
+          <div>When importing a public collection:</div>
+          <div>&emsp;&emsp;The collection URL should look like: https://partner.archive-it.org/[organization_id]/collections/[collection_id]</div>
+          <div>&emsp;&emsp;This will import/update all public seeds in the collection as a background job.</div>
           <br>
           <div>Note that collections must first be mapped to resources before they can be imported.</div>
         begin_job_page: |

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -2,5 +2,58 @@ en:
   plugins:
     archive_it:
       label: Archive-It Import
+      labels:
+        import_page_header: Import from Archive-It
+        mapping_page_header: Edit the Archive-It Collection Map
+        ai_id: Archive-It Collection ID
+        as_id: ArchivesSpace Resource ID
       actions:
         import: Import
+        remove: Remove
+        save: Save
+        revert: Revert unsaved changes
+        add_mapping: Add new mapping
+      messages:
+        service_notice: This plugin depends on the Archive-It web API that may or may not be available or supported.
+        enter_url: Enter a seed or collection URL
+        fix_mapping: Fix the collection mapping for \#{id}
+        saved: The collection mapping has been saved
+        enter_ai_id: Enter Archive-It collection ID
+        enter_as_id: Enter ArchivesSpace resource ID
+        link_to_mapping: Configure the collection mapping here
+      errors:
+        no_mapping: No mapping existed for the collection ID \#{id}.
+        collection_not_found: No seeds were found for collection ID \#{id}. Does the collection exist and is it public?
+        seed_not_found: Could not find seed ID \#{id}. Does the seed exist and is it public?
+        no_resource: Cannot map collection ID \#{id} to an invalid ArchivesSpace resource ID \#{id2}.
+        collection_empty: There are no seeds to import from collection ID \#{id}. Are the seeds private?
+      about:
+        configuring_mapping: |
+          <div>To add a new mapping, just press the "Add new mapping" button and configure the new entry.</div>
+          <div>The Archive-It ID must be valid ID for a public collection.</div>
+          <div>The ArchiveSpace Resource field must be an ArchivesSpace resource ID.</div>
+        importing_url: |
+          <div>Copy and paste a public seed or collection URL from the Archive-It administrative interface.</div>
+          <br>
+          <div>To import a public seed:</div>
+          <div>The seed URL should look like: https://partner.archive-it.org/[organization_id]/collections/[collection_id]/seeds/[seed_id]</div>
+          <div>A new archival object will be created for the seed. You will be redirected to the new archival object.</div>
+          <br>
+          <div>To import a public collection:</div>
+          <div>The collection URL should look like: https://partner.archive-it.org/[organization_id]/collections/[collection_id]</div>
+          <div>The new archival objects will be created for each public seed. This will run as a background job.</div>
+          <br>
+          <div>Note that collections must first be mapped to resources before they can be imported.</div>
+        begin_job_page: |
+          <br>
+          <div><b>Do not use this page to start an Archive-It import job.</b></div>
+          <br>
+          <div>Instead, use the gear icon next to the repository on the top right, then go to <a href="/plugins/archive_it">Plug-ins > Archive-It Import</a>.</div>
+    archive_it_collection_map:
+      label: Archive-It Collection Map
+  archive_it_import_job:
+    collection_url: Collection URL
+    resource_uri: Mapped resource URI
+  job:
+    types:
+      archive_it_import_job: Archive-It Import

--- a/frontend/models/archive_it.rb
+++ b/frontend/models/archive_it.rb
@@ -167,7 +167,8 @@ class ArchiveItImporter
         wayback_url = "https://wayback.archive-it.org/#{seed_metadata['collection']}/*/#{seed_metadata['url']}"
 
         digital_object['title'] = seed_metadata["url"]
-        digital_object['file_versions'] = [{file_uri: wayback_url, xlink_show_attribute: 'new', xlink_actuate_attribute: 'onRequest'}]
+        digital_object['file_versions'] = [{file_uri: wayback_url, xlink_show_attribute: 'new', xlink_actuate_attribute: 'onRequest', publish: true}]
+        digital_object['publish'] = true
         
         if title != nil then
             digital_object['notes'] = [{type: 'note', publish: true, content: ["Website title: #{title}"], jsonmodel_type: 'note_digital_object'}]

--- a/frontend/models/archive_it.rb
+++ b/frontend/models/archive_it.rb
@@ -161,7 +161,8 @@ class ArchiveItImporter
         ##########################################################
         # Update the digital object
 
-        digital_object = JSONModel::HTTP::get_json(archival_object['instances'][0]['digital_object']['ref'])
+        digital_uri = archival_object['instances'][0]['digital_object']['ref']
+        digital_object = JSONModel::HTTP::get_json(digital_uri)
 
         wayback_url = "https://wayback.archive-it.org/#{seed_metadata['collection']}/*/#{seed_metadata['url']}"
 
@@ -174,7 +175,7 @@ class ArchiveItImporter
             digital_object['notes'] = []
         end
 
-        digital_object_response = JSONModel::HTTP::post_json(URI(digital_object_uri), digital_object.to_json)
+        digital_object_response = JSONModel::HTTP::post_json(URI("#{JSONModel::HTTP.backend_url}#{digital_uri}"), digital_object.to_json)
 
 
 

--- a/frontend/models/archive_it.rb
+++ b/frontend/models/archive_it.rb
@@ -160,8 +160,15 @@ class ArchiveItImporter
         wayback_url = "https://wayback.archive-it.org/#{seed_metadata['collection']}/*/#{seed_metadata['url']}"
 
         digital_object['title'] = seed_metadata["url"]
-        digital_object['file_versions'] = [{:file_uri => wayback_url, :xlink_show_attribute => 'new', :xlink_actuate_attribute => 'onRequest'}]
-        digital_object['notes'] = [{:type => 'note', :publish => true, :content => ['view captures'], :jsonmodel_type => 'note_digital_object'}]
+        digital_object['file_versions'] = [{file_uri: wayback_url, xlink_show_attribute: 'new', xlink_actuate_attribute: 'onRequest'}]
+        
+        if title != nil then
+            digital_object['notes'] = [{type: 'note', publish: true, content: ["Website title: #{title}"], jsonmodel_type: 'note_digital_object'}]
+        else
+            digital_object['notes'] = []
+        end
+
+        digital_object_response = JSONModel::HTTP::post_json(URI(digital_object_uri), digital_object.to_json)
 
 
 
@@ -175,15 +182,7 @@ class ArchiveItImporter
         archival_object['other_level'] = "seed"
 
 
-        title = seed_metadata['metadata']['Title']
-        
-        if title == nil then
-            title = "Seed URL"
-        else
-            title = title[0]['value']
-        end
-
-        archival_object['external_documents'] = [{'title' => 'Archive-It URL', 'location' => "#{@collection_url}/seeds/#{seed_id}"}, {'title' => title, 'location' => "#{seed_metadata['url']}"}]
+        archival_object['external_documents'] = [{'title' => 'Archive-It URL', 'location' => "#{@collection_url}/seeds/#{seed_id}"}, {'title' => title || "Seed URL", 'location' => "#{seed_metadata['url']}"}]
         
 
         ##########################################################

--- a/frontend/models/archive_it.rb
+++ b/frontend/models/archive_it.rb
@@ -3,53 +3,144 @@ require 'net/http'
 require 'securerandom'
 
 class ArchiveItImporter
-    def initialize(seed_url, archival_object_post_uri, digital_object_post_uri, collection_resource_map_uri)
+
+    def initialize(seed_url, session)
+        archival_object_post_uri = "#{JSONModel::HTTP.backend_url}/repositories/#{session[:repo_id]}/archival_objects"
+        digital_object_post_uri = "#{JSONModel::HTTP.backend_url}/repositories/#{session[:repo_id]}/digital_objects"
+        archive_it_mapping = JSON.parse(JSONModel::HTTP::get_json("/current_archive_it_mapping"))
+
+        @session = session
         @seed_url = seed_url
-        @seed_id = seed_url.split("/")[-1]
+
+        url_components = seed_url.split("/")
+
+        if url_components[-2] == "seeds" then
+            @seed_ids = [url_components[-1]]
+            @collection_id = url_components[-3]
+            @one_seed = true
+        else
+            @collection_id = url_components[-1]
+
+            @seed_ids = get_seeds_in_collection(@collection_id).map(&:to_s)
+            
+            if @seed_ids == [] then
+                raise "collection_not_found:#{@collection_id}"
+            end
+        end
+
+        if (not archive_it_mapping.key?(@collection_id) ) || archive_it_mapping[@collection_id] == "" then
+            raise "no_mapping:" + @collection_id
+        end
+
+        resource_id = archive_it_mapping[@collection_id]
+
+        # Find collection uri
+        search = JSONModel::HTTP::get_json("/search?q=#{resource_id}&fields[]=identifier,uri&type[]=resource&page=1&page_size=1")
+        
+        if search == nil then
+            @resource_uri = JSONModel(:resource).uri_for(resource_id)
+        else
+            raise "no_resource:#{@collection_id}:#{resource_id}"
+        end
+
+        # Check if the mapped resource is present in ArchivesSpace
+        # Todo: Is this unnecessary from the code above?
+        begin
+            resource = JSONModel::HTTP::get_json(JSONModel(:resource).uri_for(resource_id))
+            if resource == nil then
+                raise ""
+            end
+        rescue Exception => ex
+            raise "no_resource:#{@collection_id}:#{resource_id}"
+        end
+
         @archival_object_post_uri = archival_object_post_uri
         @digital_object_post_uri = digital_object_post_uri
-        @collection_resource_map_uri = collection_resource_map_uri
     end
 
-    def get_seed_metadata
-        api_url = "https://partner.archive-it.org/api/seed/#{@seed_id}"
-        api_uri = URI(api_url)
+    def get_seeds_in_collection(collection_id)
+        api_uri = URI("https://partner.archive-it.org/api/seed?collection=#{collection_id}&pluck=id&limit=10000")
         response = Net::HTTP.get(api_uri)
+
         JSON.parse(response)
     end
 
-    def create_digital_object
-        wayback_url = "https://wayback.archive-it.org/#{@seed_metadata['collection']}/*/#{@seed_metadata['url']}"
+    def get_seed_metadata(seed_id)
+        api_uri = URI("https://partner.archive-it.org/api/seed/#{seed_id}")
+        response = Net::HTTP.get(api_uri)
+
+        JSON.parse(response)
+    end
+
+    def create_digital_object(seed_metadata)
+        wayback_url = "https://wayback.archive-it.org/#{seed_metadata['collection']}/*/#{seed_metadata['url']}"
         digital_object = JSONModel(:digital_object).new._always_valid!
-        digital_object.title = @seed_metadata["url"]
+        digital_object.title = seed_metadata["url"]
         digital_object.digital_object_id = SecureRandom.hex
         digital_object.file_versions = [{:file_uri => wayback_url, :xlink_show_attribute => 'new', :xlink_actuate_attribute => 'onRequest'}]
-        digital_object.notes = [{:type => 'note', :publish => true, :content => ['view captures'], :jsonmodel_type => 'note_digital_object'}]
+        #digital_object.notes = [{:type => 'note', :publish => true, :content => ['view captures'], :jsonmodel_type => 'note_digital_object'}]
         digital_object_response = JSONModel::HTTP::post_json(URI(@digital_object_post_uri), digital_object.to_json)
         result = ASUtils.json_parse(digital_object_response.body)
         digital_object_uri = result["uri"]
         digital_object_uri
     end
 
-    def create_archival_object
-        @seed_metadata = get_seed_metadata
-        collection_resource_map = JSONModel::HTTP::get_json(URI(@collection_resource_map_uri))
-        collection_id = @seed_metadata["collection"].to_s
-        resource_id = collection_resource_map[collection_id]
-        digital_object_uri = create_digital_object
-        site_url = @seed_metadata["url"]
+    def create_archival_object(seed_id)
+        seed_metadata = get_seed_metadata(seed_id)
+
+        if seed_metadata["detail"] == "Not found" then
+            raise "seed_not_found:" + seed_id;
+        end
+
+        collection_id = seed_metadata["collection"].to_s
+        digital_object_uri = create_digital_object(seed_metadata)
+        site_url = seed_metadata["url"]
+
+
         archival_object = JSONModel(:archival_object).new._always_valid!
-        archival_object.resource = {'ref' => JSONModel(:resource).uri_for(resource_id)}
+
+        archival_object.resource = {'ref' => @resource_uri}
         archival_object.title = site_url
-        archival_object.component_id = @seed_id
+        archival_object.component_id = seed_id
         archival_object.level = "otherlevel"
         archival_object.other_level = "seed"
         archival_object.instances = [{:instance_type => 'digital_object', :digital_object => {:ref => digital_object_uri}}]
-        archival_object.external_documents = [{:title => 'Archive-It URL', :location => @seed_url}, {:title => 'Seed URL', :location => "#{@seed_metadata['url']}"}]
+
+        archival_object.external_documents = [{:title => 'Archive-It URL', :location => @seed_url}, {:title => 'Seed URL', :location => "#{seed_metadata['url']}"}]
+        
         archival_object_response = JSONModel::HTTP::post_json(URI(@archival_object_post_uri), archival_object.to_json)
+
         result = ASUtils.json_parse(archival_object_response.body)
+
         archival_object_uri = result["uri"]
         archival_object_uri
+    end
+
+    def create_archival_objects
+
+        if @one_seed then
+            return Resolver.new(create_archival_object(@seed_ids[0])).view_uri
+        end
+
+
+        # If importing multiple seeds, make a background job
+
+        job_type = 'archive_it_import_job'
+        job_data = {'jsonmodel_type' => job_type}
+        
+        job_data['collection_url'] = @seed_url
+        job_data['resource_uri'] = @resource_uri
+
+        job = Job.new(job_type, job_data, [], {
+            :backend => JSONModel::HTTP::backend_url,
+            :session => @session[:session]
+        })
+        uploaded = job.upload
+
+
+        parts = uploaded['uri'].split('/');
+        return "/#{parts[3]}/#{parts[4]}"
+
     end
 
 end

--- a/frontend/models/archive_it.rb
+++ b/frontend/models/archive_it.rb
@@ -151,6 +151,12 @@ class ArchiveItImporter
         end
 
 
+        title = seed_metadata['metadata']['Title']
+        
+        if title != nil then
+            title = title[0]['value']
+        end
+
 
         ##########################################################
         # Update the digital object

--- a/frontend/models/archive_it.rb
+++ b/frontend/models/archive_it.rb
@@ -220,9 +220,11 @@ class ArchiveItImporter
                 archival_object = JSONModel::HTTP::get_json(URI(records[seed]))
 
                 archival_uri = "#{JSONModel::HTTP::backend_url}#{records[seed]}"
-                return Resolver.new(refresh_archival_object(archival_object, seed, metadata, archival_uri)).view_uri
+                seed_uri = refresh_archival_object(archival_object, seed, metadata, archival_uri)
+                
+                return Resolver.new(seed_uri).view_uri, false
             else
-                return Resolver.new(create_archival_object(seed)).view_uri
+                return Resolver.new(create_archival_object(seed)).view_uri, true
             end
         end
 

--- a/frontend/routes.rb
+++ b/frontend/routes.rb
@@ -6,6 +6,8 @@ ArchivesSpace::Application.routes.draw do
       match('/plugins/archive_it' => 'archive_it#index', :via => [:get])
       match('/plugins/archive_it/:id/download_marc' => 'archive_it#download_marc', :via => [:get])
       match('/plugins/archive_it/import' => 'archive_it#import', :via => [:post])
+      match('/plugins/archive_it_collection_map' => 'archive_it_collection_map#index', :via => [:get])
+      match('/plugins/archive_it/collection_map/save' => 'archive_it_collection_map#save_mapping', :via => [:post])
     end
   end
 end

--- a/frontend/views/archive_it/index.html.erb
+++ b/frontend/views/archive_it/index.html.erb
@@ -1,25 +1,40 @@
-<%= setup_context :title => "Archive-It Import" %>
+<%= setup_context :title => I18n.t("plugins.archive_it.label") %>
 
 <div class="row">
-  <div class="col-md-12">
-    <h2>Import from Archive-It</h2>
+    <div class="col-md-12">
+		<h2><%= I18n.t("plugins.archive_it.labels.import_page_header") %></h2>
 
-    <%= render_aspace_partial :partial => "shared/flash_messages" %>
+		<%= render_aspace_partial :partial => "shared/flash_messages" %>
 
-    <%= form_tag({:controller => :archive_it, :action => :import}, {:class => "form-horizontal"}) do |form| %>
+		<% if @fix_collection then %>
+			<form action="./archive_it_collection_map">
+				<input type="hidden" name="fix" value="<%= @fix_collection %>">
+				<button class="btn btn-primary" autofocus>
+					<%=
+						message = I18n.t("plugins.archive_it.messages.fix_mapping")
+						id = @fix_collection
+						eval("\"#{message}\"".gsub(/\\/, ""))
+					%>
+				</button>
+			</form>
+			<br/>
+		<% end %>
+		
+		<%= form_tag({:controller => :archive_it, :action => :import}, {:class => "form-horizontal"}) do |form| %>
 
-      <div class="input-group input-group-lg"> 
-        <input type="text" name="seed_url" class="form-control" placeholder="Enter a seed URL">
-        <div class="input-group-btn">
-          <button class="btn btn-primary btn-default" type="submit">
-            <%= I18n.t("plugins.archive_it.actions.import") %>
-          </button>
-        </div>
-      </div>
-    <% end %>
-    <br/>
-    <div>Copy and paste a seed URL from the Archive-It administrative interface.</div>
-    <div>The URL should look like: https://partner.archive-it.org/934/collections/[collection_id]/seeds/[seed_id]</div>
-    <div>A new archival object will be created for the seed. You will be redirected to the new archival object.</div>
-  </div>
+			<div class="input-group input-group-lg">
+				<input type="text" name="seed_url" class="form-control" placeholder="<%= I18n.t("plugins.archive_it.messages.enter_url") %>">
+				<div class="input-group-btn">
+					<button class="btn btn-primary btn-default" type="submit">
+						<%= I18n.t("plugins.archive_it.actions.import") %>
+					</button>
+				</div>
+			</div>
+		<% end %>
+
+		<br/>
+		<%= I18n.t("plugins.archive_it.about.importing_url") %>
+		<br/>
+		<p><a href="/plugins/archive_it_collection_map"><%= I18n.t("plugins.archive_it.messages.link_to_mapping") %></a></p>
+    </div>
 </div>

--- a/frontend/views/archive_it_collection_map/index.html.erb
+++ b/frontend/views/archive_it_collection_map/index.html.erb
@@ -1,0 +1,180 @@
+<%= setup_context :title => I18n.t("plugins.archive_it_collection_map.label") %>
+
+<div class="row">
+	<div class="col-md-12">
+		<h2><%= I18n.t("plugins.archive_it.labels.mapping_page_header") %></h2>
+
+		<%= render_aspace_partial :partial => "shared/flash_messages" %>
+
+		<div><%= I18n.t("plugins.archive_it.messages.service_notice") %></div>
+		<br/>
+		<%= I18n.t("plugins.archive_it.about.configuring_mapping") %>
+		<br/>
+		<%= form_tag({:controller => :archive_it_collection_map, :action => :save_mapping}, {:class => "form-horizontal"}) do |form| %>
+
+			<div class="container">
+				<div class="col-lg-2"></div>
+				<div class="col-lg-8">
+				<table class="table table-bordered table-sm align-middle">
+					<thead>
+					<th class="mx-auto col-sm-6" scope="col">
+					<%= I18n.t("plugins.archive_it.labels.ai_id") %>
+					</th>
+					<th class="mx-auto col-sm-6" scope="col">
+					<%= I18n.t("plugins.archive_it.labels.as_id") %>
+					</th>
+					<th>
+						<button style="visibility: hidden;" class="btn btn-xs"><%= I18n.t("plugins.archive_it.actions.remove") %></button>
+					</th>
+					<tbody id="tableBody"></tbody>
+				</table>
+				<br/>
+					<button class="btn btn-default" onclick="addRow()" type="button">
+						<%= I18n.t("plugins.archive_it.actions.add_mapping") %>
+					</button>
+					<button class="btn btn-primary pull-right" type="submit" style="margin-left: 2rem;">
+						<%= I18n.t("plugins.archive_it.actions.save") %>
+					</button>
+					<a href="./archive_it_collection_map">
+						<button class="btn btn-default pull-right" type="button">
+							<%= I18n.t("plugins.archive_it.actions.revert") %>
+						</button>
+					</a>
+				</div>
+			</div>
+		
+		<% end %>
+		<br/>
+
+		<!--
+		<div class="input-group linker-wrapper">
+			<input type="text" class="linker"
+					id="collection_resource"
+					data-label="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource_singular") %>"
+					data-label_plural="<%= I18n.t("top_container._frontend.bulk_operations.collection_resource_plural") %>"
+					data-name="ref"
+					data-path="collection_resource"
+					data-url="<%= url_for  :controller => :search, :action => :do_search, :format => :json %>"
+					data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => [], :sort => "title_sort asc" %>"
+					data-selected="{}"
+					data-multiplicity="one"
+					data-types='<%= ['resource'].to_json %>'
+			/>
+			<div class="input-group-btn">
+				<a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);" title="Link to resource" aria-label="Link to resource"><span class="caret"></span></a>
+				<ul class="dropdown-menu">
+				<li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
+				</ul>
+			</div>
+		</div>
+		-->
+
+		<script>{
+			const $ = function(tagAndClassNames = null, attributes = null, children = null){
+				if(tagAndClassNames == null || tagAndClassNames == ''){
+					return document.createTextNode(attributes ?? '');
+				}
+				if(tagAndClassNames[0] == '#'){
+					return document.getElementById(tagAndClassNames.slice(1));
+				}
+
+				let tag_id_classes = tagAndClassNames.split('.');
+
+				let tag_id = tag_id_classes[0].split('#');
+				const elem = document.createElement(tag_id[0]);
+				if(tag_id.length == 2){
+					elem.id = tag_id[1];
+				}
+				elem.className = tag_id_classes.slice(1).join(' ');
+
+				if(children == null && Array.isArray(attributes)){
+					children = attributes;
+				}
+				else {
+					for(const attr in attributes ?? {}){
+						elem[attr] = attributes[attr];
+					}
+				}
+
+				for(const child of children ?? []){
+					if(typeof child === 'string' || child instanceof String)
+						elem.appendChild(document.createTextNode(child ?? ''));
+					else
+						elem.appendChild(child)
+				}
+
+				return elem;
+			}
+
+			const newTD = function(row, type, placeholder, value, onclick){
+				return $('td', [
+					$('div.input-group', [
+						$('input.form-control', {type: "text", name: `${row}${type}`, placeholder, autocomplete: 'off', value}),
+						$('span.input-group-btn', [
+							$('button.btn.btn-default', {onclick, type: "button"}, ["View"])
+						])
+					])
+				]);
+			}
+
+			const viewArchiveIt = function(id){
+				const ai_id = $(`#${id}`).children[0].children[0].children[0].value;
+
+				open(`https://partner.archive-it.org/api/collection/${ai_id}`);
+			}
+
+			const viewArchivesSpace = function(id){
+				const as_id = $(`#${id}`).children[1].children[0].children[0].value;
+				
+				open(`../resources/${as_id}`);
+			}
+
+			let row = 0;
+			
+			function addRow(archiveItID, archivesSpaceID, focused = false){
+				let row_id = `row${row}`;
+				$('#tableBody').appendChild($(`tr#${row_id}`, [
+					newTD(row_id, "ai", "<%= I18n.t("plugins.archive_it.messages.enter_ai_id") %>", archiveItID ?? "", () => viewArchiveIt(row_id)),
+					newTD(row_id, "as", "<%= I18n.t("plugins.archive_it.messages.enter_as_id") %>", archivesSpaceID ?? "", () => viewArchivesSpace(row_id)),
+					$('td', [$('button.btn.btn-xs.btn-danger', {onclick: () => removeRow(row_id)}, ["<%= I18n.t("plugins.archive_it.actions.remove") %>"])]),
+				]));
+				
+				if(focused){
+					$(`#${row_id}`).children[1].children[0].children[0].focus();
+				}
+
+				row += 1;
+			}
+			
+			function removeRow(id){
+				$('#tableBody').removeChild($(`#${id}`));
+			}
+
+			const fix_collection = <%= @fix || 0 %>;
+			let found_fixed = false;
+
+			function load_current_mapping(){
+				const current_mapping = JSON.parse("<%= @current_mapping.to_json %>".replace(/&quot;/g, '"'));
+
+				const tbody = $('#tableBody');
+
+				while(tbody.firstChild){
+					tbody.removeChild(tbody.firstChild)
+				}
+
+				for(const id in current_mapping){
+					if(id == fix_collection){
+						found_fixed = true;
+					}
+					addRow(id, current_mapping[id], id == fix_collection);
+				}
+			}
+
+			load_current_mapping();
+
+			if(fix_collection && !found_fixed){
+				addRow(fix_collection, null, true);
+			}
+		}</script>
+	</div>
+</div>

--- a/frontend/views/archive_it_import_job/_form.html.erb
+++ b/frontend/views/archive_it_import_job/_form.html.erb
@@ -1,0 +1,1 @@
+<%= I18n.t("plugins.archive_it.about.begin_job_page") %>

--- a/frontend/views/archive_it_import_job/_show.html.erb
+++ b/frontend/views/archive_it_import_job/_show.html.erb
@@ -1,0 +1,8 @@
+<div class="form-group">
+	<label class="col-sm-3 control-label">Collection URL</label>
+	<div class="col-sm-9 controls label-only"><%= job['collection_url'] %></div>
+</div>
+<div class="form-group">
+	<label class="col-sm-3 control-label">Mapped resource URI</label>
+	<div class="col-sm-9 controls label-only"><%= job['resource_uri'] %></div>
+</div>

--- a/schemas/archive_it_import_job.rb
+++ b/schemas/archive_it_import_job.rb
@@ -1,0 +1,19 @@
+{
+  :schema => {
+    "$schema" => "http://www.archivesspace.org/archivesspace.json",
+    "version" => 1,
+    "type" => "object",
+
+    "properties" => {
+      
+      "collection_url" => {
+        "type" => "string",
+        "ifmissing" => "error"
+      },
+      "resource_uri" => {
+        "type" => "string",
+        "ifmissing" => "error"
+      },
+    }
+  }
+}


### PR DESCRIPTION
Hello! I've made a number of improvements to this plug-in.

1. The collection mapping is now configurable from within ArchivesSpace, and does not require a restart to be active. The previous mapping configuration  in `config/config.rb` is ignored. Instead, the plug-in automatically saves to and reads from `config/archive_it_mapping.json`.

   Here's screenshots of this new GUI.
![image](https://user-images.githubusercontent.com/37983677/157980342-534b237e-665e-4c30-949d-787033dfc45f.png)
![image](https://user-images.githubusercontent.com/37983677/157980437-d0e07c7b-b200-488d-a8d6-b2f3d8947597.png)

2. Entire collections can be imported in one operation. The user can import collections the same way individual seeds are imported. However, the operation will run as a background job since it can take a few minutes to run.

   Here's screenshots from importing a collection.
![image](https://user-images.githubusercontent.com/37983677/157985271-3c134262-c9b1-4cbd-ab49-04eb7ab486b3.png)
![image](https://user-images.githubusercontent.com/37983677/157983745-558a5af9-2fad-4e10-a13d-dd4eaabfc228.png)
![image](https://user-images.githubusercontent.com/37983677/157983936-02b2677b-4cc3-4640-8492-3acdef0e7ec1.png)
![image](https://user-images.githubusercontent.com/37983677/157984084-79562950-802b-4660-a37e-2f0642efd145.png)

3. Duplicate seeds are merged. The plug-in automatically detects if a seed has already been imported to a resource (by searching the Component Unique Identifier, which is set to the seed ID during the import process), and if one is already present, its contents will be overwritten with the latest metadata. This means that the existing object hierarchy for seeds is maintained, although new seeds will be placed at the top level in the hierarchy.

4. Error messages are presented to the user for common errors. The plug-in checks for: importing from an unrecognized or invalid Archive-It collection ID, importing from an empty collection (or a collection with no public seeds), and importing to an invalid ArchivesSpace resource ID.
![image](https://user-images.githubusercontent.com/37983677/157984454-5e317b0d-e682-4a5c-9af7-bbad95fd2b77.png)

5. The 'file versions' field of digital objects for seeds are now set to published by default. This helps with the EAD and PDF export process.